### PR TITLE
Remove Youtube dislike count parsing

### DIFF
--- a/lib/resolvers/youtube.js
+++ b/lib/resolvers/youtube.js
@@ -54,12 +54,12 @@ export default class YouTube extends Resolver {
 
 		video.statistics = video.statistics || {};
 
+		// RIP dislike counter Nov 2021
 		const line_one = this.builder().addI18n(
-			'embed.youtube.info-1', '{channel} • {views,plural,one {# View} other {{views,number} Views}} • 👍 {likes,number}  • 👎 {dislikes,number}', {
+			'embed.youtube.info-1', '{channel} • {views,plural,one {# View} other {{views,number} Views}} • 👍 {likes,number}', {
 				channel: video.snippet.channelTitle,
 				views: video.statistics.viewCount || 0,
-				likes: video.statistics.likeCount || 0,
-				dislikes: video.statistics.dislikeCount || 0
+				likes: video.statistics.likeCount || 0
 			}
 		);
 


### PR DESCRIPTION
Considering Youtube no longer returns a dislike count on any video unless you are authenticated as the uploader, this seems to be just extra overhead for the link resolver, if only a little.

Thanks,
pointy